### PR TITLE
Add Google Analytics tracking script to index.html

### DIFF
--- a/index.html
+++ b/index.html
@@ -2,6 +2,17 @@
 <html lang="en">
 
 <head>
+    
+    <!-- Google tag (gtag.js) -->
+    <script async src="https://www.googletagmanager.com/gtag/js?id=G-MKL7CBMTWB"></script>
+    <script>
+        window.dataLayer = window.dataLayer || [];
+        function gtag(){dataLayer.push(arguments);}
+        gtag('js', new Date());
+
+        gtag('config', 'G-MKL7CBMTWB');
+    </script>
+
     <meta charset="UTF-8">
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">


### PR DESCRIPTION
This pull request includes a small change to the `index.html` file. The change integrates Google Analytics by adding the `gtag.js` script to the head section of the HTML.

* [`index.html`](diffhunk://#diff-0eb547304658805aad788d320f10bf1f292797b5e6d745a3bf617584da017051R5-R15): Added Google Analytics script to enable tracking.